### PR TITLE
Refactored fixSeqWareTSV() as Run Report format changed

### DIFF
--- a/app.R
+++ b/app.R
@@ -85,7 +85,7 @@ server <- function(session, input, output) {
     selected.study <- current.run()[[input$study]]
     req(selected.study)
     
-    coverage.max <- max(selected.study[, "Coverage"])
+    coverage.max <- max(selected.study[, "Coverage (collapsed)"])
     updateSliderInput(session, "slider.coverage", max = coverage.max, value = c(0, coverage.max))
     
     if (is.null(input$check.type)) {
@@ -109,14 +109,14 @@ server <- function(session, input, output) {
     
     # Make Lanes a factor rather than number and sort by lane and then by coverage
     set(selected.study, j = "Lane", value = factor(selected.study$Lane, levels = lane.levels, ordered = TRUE))
-    setorder(selected.study, Lane, -Coverage)
+    setorder(selected.study, Lane, -`Coverage (collapsed)`)
     
     # Libraries should also be factors rather than strings
     set(selected.study, j = "Library", value = factor(selected.study$Library, levels = unique(selected.study$Library, ordered = TRUE)))
     
     # Filter by Coverage
     selected.coverage <- input$slider.coverage
-    selected.study <- selected.study[Coverage >= selected.coverage[1] & Coverage <= selected.coverage[2],]
+    selected.study <- selected.study[`Coverage (collapsed)` >= selected.coverage[1] & `Coverage (collapsed)` <= selected.coverage[2],]
     
     # Keep only the metrics that will be plotted 
     selected.study <- split(selected.study, by = "Type")

--- a/column_naming.csv
+++ b/column_naming.csv
@@ -1,0 +1,30 @@
+file.name,app.name,type
+Lane,Lane,Character
+Barcode,Barcode,Character
+Group ID,Group ID,Character
+External Name,External Name,Character
+Library,Library,Character
+Insert Mean (SD),#Split_Mean_SD,NA
+Insert Mean,Insert Mean,Numeric
+Insert Stddev,Insert Stddev,Numeric
+Read Length,#Split_Read1_Read2,NA
+PF Reads,PF Reads,Numeric
+PF Yield,PF Yield,Numeric
+Map Percent,Map Percent,Numeric
+R1 Mismatch Percent,R1 Mismatch Percent,Numeric
+R2 Mismatch Percent,R2 Mismatch Percent,Numeric
+R1 Indel Percent,R1 Indel Percent,Numeric
+R2 Indel Percent,R2 Indel Percent,Numeric
+R1 Soft Clip Percent,R1 Soft Clip Percent,Numeric
+R2 Soft Clip Percent,R2 Soft Clip Percent,Numeric
+Reads/SP,Reads/SP,Numeric
+Percent mapped on Target,Percent Mapped on Target,Numeric
+Percent Mapped on Target,Percent Mapped on Target,Numeric
+Estimated Yield,Estimated Yield (collapsed),Numeric
+Estimated Yield (collapsed),Estimated Yield (collapsed),Numeric
+Coverage,Coverage (collapsed),Numeric
+Coverage (collapsed),Coverage (collapsed),Numeric
+Target Size (bp),Target Size (bp),Numeric
+Number of Targets,Number of Targets,Numeric
+Target File,Target File,Character
+Run Name,Run Name,Character

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,6 @@
 app_instance:
     run_report_dir: ./runreport_files
-    default_plots: [Coverage, PF Reads, Map Percent, Reads/SP, Percent mapped on Target, Insert Size]
+    default_plots: [Coverage (collapsed), PF Reads, Map Percent, Reads/SP, Percent Mapped on Target, Insert Mean]
     port: 11038
+    column_naming: ./column_naming.csv
+    info_column: [Library, Barcode, Lane, Run Name, Coverage (collapsed), Study, Group ID, External Name, Target File]

--- a/read_config.R
+++ b/read_config.R
@@ -4,3 +4,5 @@ CONFIG <- read_yaml("./config.yaml")
 CONFIG.RUNPATH <- CONFIG$app_instance$run_report_dir
 CONFIG.DEFAULTPLOTS <- CONFIG$app_instance$default_plots
 CONFIG.PORT <- CONFIG$app_instance$port
+CONFIG.COLUMN <- CONFIG$app_instance$column_naming
+CONFIG.INFO.COLUMN <- CONFIG$app_instance$info_column

--- a/utility.R
+++ b/utility.R
@@ -1,54 +1,69 @@
+source("./read_config.R")
+
 library(data.table)
 
+# This file contains information about the expected column names, name conversions, and column types
+COLUMN.NAME <- fread(CONFIG.COLUMN)
+
 fixSeqWareTSV <- function(t.df) {
-  # Remove commas from numeric values
-  set_numeric <- c("PF Reads", "PF Yield", "Estimated Yield", "Target Size (bp)", "Number of Targets")
-  sapply(set_numeric, function(x) {
-    set(t.df, j = x, value = as.numeric(gsub(",", "", t.df[, x, with = FALSE][[1]])))
+  t.df.colnames <- colnames(t.df)
+
+  # Library column is duplicated for some reason in Run Report TSV files. This removes is.
+  # Note that if duplicated column names with different data exist, the second one will be ignored.
+  t.df.colnames <- unique(t.df.colnames)
+
+  # Create a data table for each column
+  dt.list <- lapply(t.df.colnames, function(x) {
+    conversion <- COLUMN.NAME[file.name == x,]
+    data <- t.df[[x]]
+
+    if (nrow(conversion) != 1) {
+      stop(paste("Field name", x, "cannot be unambiguously parsed. It is found", nrow(conversion), "times in the annotation file. Expected 1."))
+    }
+
+    # Split Read Length from a character column into two numeric columns
+    if(conversion$app.name == "#Split_Read1_Read2") {
+      read.length<-sapply(data, function(x) strsplit(x, ",")[[1]])
+      data <- as.data.table(list(`R1 Length` = as.numeric(read.length[1,]), `R2 Length` = as.numeric(read.length[2,])))
+      return(data)
+    }
+
+    # Split insert size and SD from a character column into two numeric columns
+    if(conversion$app.name == "#Split_Mean_SD") {
+      in.sd <-gsub("[\\(\\)]", "", data)
+      in.sd<-sapply(in.sd, function(x) strsplit(x, " ")[[1]])
+      data <- as.data.table(list(`Insert Mean` = as.numeric(in.sd[1,]), `Insert Stddev` = as.numeric(in.sd[2,])))
+      return(data)
+    }
+
+    # If it is a numeric type, only leave numbers and periods
+    if(conversion$type == "Numeric") {
+      data <- gsub("[^0-9\\.]", "", data)
+      data <- as.numeric(data)
+    }
+
+    result <- list()
+
+    # The column is renamed to canonical name
+    result[[conversion$app.name]] <- data
+    return(as.data.table(result))
   })
-  
-  # Remove percentages from numeric values
-  remove_percent <- c(
-    "Map Percent", "R1 Mismatch Percent", "R2 Mismatch Percent", "R1 Indel Percent", 
-    "R2 Indel Percent", "R1 Soft Clip Percent", "R2 Soft Clip Percent", "Percent mapped on Target"
-  )
-  sapply(remove_percent, function(x) {
-    set(t.df, j = x, value = as.numeric(gsub("%", "", t.df[, x, with = FALSE][[1]])))
-  })
-  
-  # Remove the x unicode sign from converage numeric values
-  remove_x_unicode <- "Coverage"
-  set(t.df, j = remove_x_unicode, value = as.numeric(gsub("×", "", t.df[, remove_x_unicode, with = FALSE][[1]])))
-  
-  # Split insert size and SD from a character column into two numeric columns
-  in.sd <-gsub("[\\(\\)]", "", t.df$`Insert Mean (SD)`)
-  in.sd<-sapply(in.sd, function(x) strsplit(x, " ")[[1]])
-  set(t.df, j = "Insert Size", value = as.numeric(in.sd[1,]))
-  set(t.df, j = "Insert SD", value = as.numeric(in.sd[2,]))
-  set(t.df, j = "Insert Mean (SD)", value = NULL)
-  
-  # Split Read Length from a character column into two numeric columns
-  read.length<-sapply(t.df$`Read Length`, function(x) strsplit(x, ",")[[1]])
-  set(t.df, j = "R1 Length", value = as.numeric(read.length[1,]))
-  set(t.df, j = "R2 Length", value = as.numeric(read.length[2,]))
-  set(t.df, j = "Read Length", value = NULL)
-  
-  # Remove duplicated columns
-  t.df <- t.df[,unique(names(t.df)),with=FALSE]
-  
+
+  result.dt <- as.data.table(dt.list)
+
   # Add Study name
-  set(t.df, j = "Study", value = sapply(strsplit(t.df$Library, "_"), function(x) x[[1]]))
-  
-  return(t.df)
+  set(result.dt, j = "Study", value = sapply(strsplit(result.dt$Library, "_"), function(x) x[[1]]))
+
+  return(result.dt)
 }
 
 createLong <- function(t.df) {
-  epic.dt.long <- melt(t.df[, !c("Target File")], id.vars = c("Library", "Barcode", "Lane", "Run Name", "Coverage", "Study"), variable.name = "Type", value.name = "Value")
+  epic.dt.long <- melt(t.df, id.vars = intersect(CONFIG.INFO.COLUMN, colnames(t.df)), variable.name = "Type", value.name = "Value")
   
   # Add back the coverage metrics so it generates its own graph
   epic.dt.coverage <- epic.dt.long[Type == epic.dt.long[1,]$Type, ]
-  set(epic.dt.coverage, j = "Value", value = epic.dt.coverage$Coverage)
-  set(epic.dt.coverage, j = "Type", value = rep("Coverage", nrow(epic.dt.coverage)))
+  set(epic.dt.coverage, j = "Value", value = epic.dt.coverage$`Coverage (collapsed)`)
+  set(epic.dt.coverage, j = "Type", value = rep("Coverage (collapsed)", nrow(epic.dt.coverage)))
   
   epic.dt.long <- rbindlist(list(epic.dt.coverage, epic.dt.long))
   
@@ -61,7 +76,7 @@ createLong <- function(t.df) {
 readSeqWareTSV <- function(path) {
   tryCatch({
     
-    dt <- fread(path, sep = "\t", header = TRUE)
+    dt <- fread(path, sep = "\t", header = TRUE, na.strings = c("NA", "na"))
     set(dt, j = "Run Name", value = factor(rep(path, nrow(dt))))
     
   }, warning = function(w) {


### PR DESCRIPTION
The Run Report is being upgraded to make it more machine readable. The
new report throws an error due to changes in column naming. To
allow the reading of differently formatted Run Reports, a column_naming
file is provided, specifying the Run Report column names that are in use
and the canonical names that will be used in the app.