### PR TITLE
Sane addition of Custom Metrics + On Target field from Read Breakdown

### DIFF
--- a/column_naming.csv
+++ b/column_naming.csv
@@ -28,3 +28,5 @@ Target Size (bp),Target Size (bp),Numeric,
 Number of Targets,Number of Targets,Numeric,
 Target File,Target File,Character,
 Run Name,Run Name,Character,This field is added by the app and not present in the Run Report
+Study,Study,Character,This field is MISO Project Name derived from Library
+On Target Percentage,On Target Percentage,Numeric,Calculated by: Percent Mapped on Target * Map Percent / 100

--- a/column_naming.csv
+++ b/column_naming.csv
@@ -1,30 +1,30 @@
-file.name,app.name,type
-Lane,Lane,Character
-Barcode,Barcode,Character
-Group ID,Group ID,Character
-External Name,External Name,Character
-Library,Library,Character
-Insert Mean (SD),#Split_Mean_SD,NA
-Insert Mean,Insert Mean,Numeric
-Insert Stddev,Insert Stddev,Numeric
-Read Length,#Split_Read1_Read2,NA
-PF Reads,PF Reads,Numeric
-PF Yield,PF Yield,Numeric
-Map Percent,Map Percent,Numeric
-R1 Mismatch Percent,R1 Mismatch Percent,Numeric
-R2 Mismatch Percent,R2 Mismatch Percent,Numeric
-R1 Indel Percent,R1 Indel Percent,Numeric
-R2 Indel Percent,R2 Indel Percent,Numeric
-R1 Soft Clip Percent,R1 Soft Clip Percent,Numeric
-R2 Soft Clip Percent,R2 Soft Clip Percent,Numeric
-Reads/SP,Reads/SP,Numeric
-Percent mapped on Target,Percent Mapped on Target,Numeric
-Percent Mapped on Target,Percent Mapped on Target,Numeric
-Estimated Yield,Estimated Yield (collapsed),Numeric
-Estimated Yield (collapsed),Estimated Yield (collapsed),Numeric
-Coverage,Coverage (collapsed),Numeric
-Coverage (collapsed),Coverage (collapsed),Numeric
-Target Size (bp),Target Size (bp),Numeric
-Number of Targets,Number of Targets,Numeric
-Target File,Target File,Character
-Run Name,Run Name,Character
+file.name,app.name,type,comment
+Lane,Lane,Character,
+Barcode,Barcode,Character,
+Group ID,Group ID,Character,
+External Name,External Name,Character,
+Library,Library,Character,
+Insert Mean (SD),#Split_Mean_SD,NA,
+Insert Mean,Insert Mean,Numeric,
+Insert Stddev,Insert Stddev,Numeric,
+Read Length,#Split_Read1_Read2,NA,
+PF Reads,PF Reads,Numeric,
+PF Yield,PF Yield,Numeric,
+Map Percent,Map Percent,Numeric,
+R1 Mismatch Percent,R1 Mismatch Percent,Numeric,
+R2 Mismatch Percent,R2 Mismatch Percent,Numeric,
+R1 Indel Percent,R1 Indel Percent,Numeric,
+R2 Indel Percent,R2 Indel Percent,Numeric,
+R1 Soft Clip Percent,R1 Soft Clip Percent,Numeric,
+R2 Soft Clip Percent,R2 Soft Clip Percent,Numeric,
+Reads/SP,Reads/SP,Numeric,
+Percent mapped on Target,Percent Mapped on Target,Numeric,
+Percent Mapped on Target,Percent Mapped on Target,Numeric,
+Estimated Yield,Estimated Yield (collapsed),Numeric,
+Estimated Yield (collapsed),Estimated Yield (collapsed),Numeric,
+Coverage,Coverage (collapsed),Numeric,
+Coverage (collapsed),Coverage (collapsed),Numeric,
+Target Size (bp),Target Size (bp),Numeric,
+Number of Targets,Number of Targets,Numeric,
+Target File,Target File,Character,
+Run Name,Run Name,Character,This field is added by the app and not present in the Run Report

--- a/config.yaml
+++ b/config.yaml
@@ -1,16 +1,16 @@
 app_instance:
     run_report_dir: ./runreport_files
     plots: [
-        Coverage (collapsed), Percent Mapped on Target, Map Percent, PF Reads, Reads/SP, Insert Mean,
+        Coverage (collapsed), On Target Percentage, Map Percent, PF Reads, Reads/SP, Insert Mean,
         Insert Stddev, R1 Mismatch Percent, R2 Mismatch Percent, R1 Indel Percent, R2 Indel Percent,
-        R1 Soft Clip Percent, R2 Soft Clip Percent, R1 Length, R2 Length,
+        R1 Soft Clip Percent, R2 Soft Clip Percent, R1 Length, R2 Length, Percent Mapped on Target, 
         Estimated Yield (collapsed), PF Yield, Target Size (bp), Number of Targets 
     ]
     port: 11038
     column_naming: ./column_naming.csv
     info_column: [Library, Barcode, Lane, Run Name, Study, Group ID, External Name, Target File]
 default:
-    plots: [Coverage (collapsed), Percent Mapped on Target, Map Percent, PF Reads, Reads/SP, Insert Mean]
+    plots: [Coverage (collapsed), On Target Percentage, Map Percent, PF Reads, Reads/SP, Insert Mean]
     order: 
         plot: Coverage (collapsed)
         reverse: true

--- a/list_reports.R
+++ b/list_reports.R
@@ -6,7 +6,7 @@ library(stringr)
 source("./read_config.R")
 
 listRunReports <- function() {
-  path <- list.files(normalizePath(CONFIG.RUNPATH), full.names = TRUE)
+  path <- list.files(normalizePath(CONFIG.RUNPATH), pattern = "*.tsv$", full.names = TRUE)
   file <- sapply(path, basename)
   name <- str_match(file, "(.*?)_report.tsv")[, 2]
   dt <- data.table(path = path,

--- a/utility.R
+++ b/utility.R
@@ -70,12 +70,43 @@ fixSeqWareTSV <- function(t.df) {
   result.dt <- as.data.table(dt.list)
   
   # Add Study name
-  set(result.dt,
-      j = "Study",
-      value = sapply(strsplit(result.dt$Library, "_"), function(x)
-        x[[1]]))
+  result.dt <- addCustomTSVMetrics(
+    result.dt,
+    "Study",
+    sapply(strsplit(result.dt$Library, "_"), function(x) x[[1]])
+  )
   
+  # Add On Target Percentage
+  result.dt <- addCustomTSVMetrics(
+    result.dt,
+    "On Target Percentage",
+    result.dt$`Percent Mapped on Target` * result.dt$`Map Percent` / 100
+  )
+
   return(result.dt)
+}
+
+# Add fields not present in the original TSV file
+addCustomTSVMetrics <- function(dt, field_name, field_values) {
+  if (field_name %in% colnames(dt)) {
+    stop(
+      paste(
+        "Custom field name cannot be added as it already exists:",
+        field_name
+      )
+    )
+  }
+  
+  if (!(field_name %in% COLUMN.NAME$app.name)) {
+    stop(
+      paste(
+        "Custom field not specified in annotation file:",
+        field_name
+      )
+    )
+  }
+  
+  set(dt, j = field_name, value = field_values) 
 }
 
 createLong <- function(t.df) {

--- a/utility.R
+++ b/utility.R
@@ -114,6 +114,10 @@ readSeqWareTSV <- function(path) {
         header = TRUE,
         na.strings = c("NA", "na")
       )
+    
+    if ("Run Name" %in% colnames(dt)) {
+      stop("Column 'Run Name' is used internally by the App and cannot be present in Run Report")
+    }
     set(dt, j = "Run Name", value = factor(rep(path, nrow(dt))))
     
   }, warning = function(w) {


### PR DESCRIPTION
Only TSV files in the root folder are now loaded. This avoids bugs during the transition to having all Run Report folders in the root folder (GR-562) that will allow loading data from JSON files (GR-556).

The Column Naming csv file now has a comment field for the humans among us.